### PR TITLE
feat: 토론 요약 기능

### DIFF
--- a/src/main/java/org/dorandoran/dorandoran_backend/summary/SummaryController.java
+++ b/src/main/java/org/dorandoran/dorandoran_backend/summary/SummaryController.java
@@ -1,0 +1,28 @@
+package org.dorandoran.dorandoran_backend.summary;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/summary")
+public class SummaryController {
+
+    @Autowired
+    private SummaryService summaryService;
+
+    @PostMapping
+    public ResponseEntity<?> getSummary(@RequestParam("chat_room_id") String chatRoomId) {
+
+        ResponseEntity<String> response = summaryService.requestSummaryFromAIServer(chatRoomId);
+
+        return ResponseEntity.status(response.getStatusCode())
+                .headers(response.getHeaders())
+                .body(response.getBody());
+    }
+
+}

--- a/src/main/java/org/dorandoran/dorandoran_backend/summary/SummaryService.java
+++ b/src/main/java/org/dorandoran/dorandoran_backend/summary/SummaryService.java
@@ -1,0 +1,35 @@
+package org.dorandoran.dorandoran_backend.summary;
+
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class SummaryService {
+
+    private final RestTemplate restTemplate;
+    private final String aiServerUrl = "https://sheepdog-bold-bulldog.ngrok-free.app/discussion_summary/discussion_summary";
+
+    public SummaryService() {
+        this.restTemplate = new RestTemplate();
+    }
+
+    public ResponseEntity<String> requestSummaryFromAIServer(String chatRoomId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("chat_room_id", chatRoomId);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+        return restTemplate.exchange(
+                aiServerUrl,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+    }
+}


### PR DESCRIPTION
# SummaryService 및 SummaryController 추가: 토론방 요약 요청 기능 구현

### 목적: 토론이 끝난 후, 특정 chat_room_id를 기반으로 AI 서버에 요약 요청을 보내는 기능을 구현하기 위함.